### PR TITLE
create element mock

### DIFF
--- a/packages/core/__tests__/element.ts
+++ b/packages/core/__tests__/element.ts
@@ -29,6 +29,7 @@ describe('element', () => {
     expect(updateElementMock).toBeCalledTimes(0)
 
     rerender({ test: false })
+    expect(createElementMock).toBeCalledTimes(1)
     expect(updateElementMock).toBeCalledTimes(1)
     expect(updateElementMock).toBeCalledWith(
       instance,
@@ -37,6 +38,7 @@ describe('element', () => {
     )
 
     rerender({ test: false })
+    expect(createElementMock).toBeCalledTimes(1)
     expect(updateElementMock).toBeCalledTimes(2)
     expect(updateElementMock).toBeCalledWith(
       instance,

--- a/packages/core/__tests__/layer.ts
+++ b/packages/core/__tests__/layer.ts
@@ -34,4 +34,4 @@ describe('layer', () => {
     expect(map.removeLayer).toBeCalledTimes(1)
     expect(map.removeLayer).toBeCalledWith(element.instance)
   })
-})
+});

--- a/packages/core/src/element.ts
+++ b/packages/core/src/element.ts
@@ -1,4 +1,4 @@
-import { MutableRefObject, useEffect, useRef } from 'react'
+import { MutableRefObject, useEffect, useRef, useMemo } from 'react'
 
 import { LeafletContextInterface } from './context'
 
@@ -33,9 +33,9 @@ export function createElementHook<E, P, C = any>(
     props: P,
     context: LeafletContextInterface,
   ): ReturnType<ElementHook<E, P>> {
-    const elementRef = useRef<LeafletElement<E, C>>(
-      createElement(props, context),
-    )
+    const element = useMemo(() => createElement(props, context), [])
+
+    const elementRef = useRef<LeafletElement<E, C>>(element)
     const propsRef = useRef<P>(props)
     const { instance } = elementRef.current
 


### PR DESCRIPTION
Create element mock is called on rerender, I feel it's the root case of the issue https://github.com/PaulLeCam/react-leaflet/issues/888